### PR TITLE
fix the error: redefinition of 'struct sha256_state'

### DIFF
--- a/include/rtw_security.h
+++ b/include/rtw_security.h
@@ -249,11 +249,13 @@ struct security_priv {
 #define SEC_IS_BIP_KEY_INSTALLED(sec) _FALSE
 #endif
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 15))
 struct sha256_state {
 	u64 length;
 	u32 state[8], curlen;
 	u8 buf[64];
 };
+#endif
 
 #define GET_ENCRY_ALGO(psecuritypriv, psta, encry_algo, bmcst)\
 	do {\


### PR DESCRIPTION
Tested on fedora
Kernel: 5.9.15-200.fc33.x86_64